### PR TITLE
Fix main entry condition test

### DIFF
--- a/gibo
+++ b/gibo
@@ -100,7 +100,7 @@ dump() {
 
 # --- Main entry point ----------------------
 
-if [ $# == 0 ]; then
+if [ $# -eq 0 ]; then
     usage
     exit 0
 fi


### PR DESCRIPTION
``` bash
if [ $# == 0 ] ; then
  # ...
fi
```

The above works in BASH (or probably similar shells). But it fails on DASH (default `sh` in debian).
This pull request fixes this.
