### PR TITLE
minor update for installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For additional usage instructions, run `gibo` without arguments.
 
 Assuming "~/bin/" is in your $PATH, you're ready to roll:
 
-    $ gibo --list # will initialize ~/.gitignore-boilerplates for you
+    $ gibo --upgrade # will initialize ~/.gitignore-boilerplates for you
 
 ## Tab completion in bash and zsh
 


### PR DESCRIPTION
I think `--upgrade` makes more sense as a first command to run after installation
### Why?

There is minor problem with the first run of `gibo`:

```
gibo [boilerplate boilerplate...] > .gitignore
```

cause extra output in your .gitignore file, i.e.:

```
Cloning https://github.com/github/gitignore.git to /home/wik/.gitignore-boilerplates
Cloning into '/home/wik/.gitignore-boilerplates'...
```
