### PR TITLE
Stop outputting full path of language file

### DIFF
--- a/gibo
+++ b/gibo
@@ -7,7 +7,8 @@
 # v1.0 1-May-2012 First public release
 
 remote_repo=https://github.com/github/gitignore.git
-local_repo=$HOME/.gitignore-boilerplates
+clone_repo_name=.gitignore-boilerplates
+local_repo=$HOME/$clone_repo_name
 
 version() {
     echo "$(basename $0) 1.0.1 by Simon Whitaker <simon@goosoftware.co.uk>"
@@ -80,20 +81,22 @@ upgrade() {
 
 dump() {
     init --silently
+
+    language_file="$clone_repo_name/$1.gitignore"
+    language_file_path="$HOME/$language_file"
+    global_file="$clone_repo_name/Global/$1.gitignore"
+    global_file_path="$HOME/$global_file"
     
-    language_file="$local_repo/$1.gitignore"
-    global_file="$local_repo/Global/$1.gitignore"
-    
-    if [ -e "$language_file" ]; then
+    if [ -e "$language_file_path" ]; then
         echo "### $language_file"
         echo
-        cat "$language_file"
+        cat "$language_file_path"
         echo
         echo
-    elif [ -e "$global_file" ]; then
+    elif [ -e "$global_file_path" ]; then
         echo "### $global_file"
         echo
-        cat "$global_file"
+        cat "$global_file_path"
         echo
         echo
     else


### PR DESCRIPTION
I think that it is not necessary to dump full path of language file to .gitignore.
If you feel that is not bad, please merge this.

---

if execute `$ gibo Compass Espresso` before this change.
output is

```
### /Users/user_name/.gitignore-boilerplates/Compass.gitignore

.sass-cache


### /Users/user_name/.gitignore-boilerplates/Global/Espresso.gitignore

*.esproj
```

after this change output is

```
### .gitignore-boilerplates/Compass.gitignore

.sass-cache


### .gitignore-boilerplates/Global/Espresso.gitignore

*.esproj
```
