### PR TITLE
Documentation fixes: use gibo to generate .hgignore files & typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A great benefit to using scoop, is that it provides an easy way to update its pa
     scoop update
     scoop update gibo
 
-**git installion**
+**git installation**
 
 You can download the whole `gibo` repo directly from GitHub:
 
@@ -54,7 +54,7 @@ You can download the whole `gibo` repo directly from GitHub:
 
 Then add the full gibo directory (`C:\Users\<Your User>\bin\gibo`) to your system's PATH environment variable.
 
-**manual installion**
+**manual installation**
 
 To manually install only the `gibo.bat` file, download it to your computer and save it to any directory that is in your PATH.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Alternatively, you can use `gibo-completion.zsh` as an
 [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) plugin
 by following [these instructions](https://github.com/simonwhitaker/gitignore-boilerplates/wiki/Using-gibo-as-an-ohmyzsh-plugin).
 
+## Use gibo to generate .hgignore files
+
+The `glob` .hgignore syntax for Mercurial is compatible with .gitignore syntax.
+This means that you can use gibo to generate .hgignore files, as long as the
+.hgignore files use the `glob` syntax:
+
+    echo 'syntax: glob' > .hgignore
+    $ gibo Python TextMate >> .hgignore
+
 ## Credits
 
 gibo was written by Simon Whitaker ([@s1mn](http://twitter.com/s1mn))


### PR DESCRIPTION
Hello Simon,

I looked around, trying to figure out if a gibo alternative was available for Mercurial/.hgignore files. I even considered writing one.
But in practice, .hgignore can just reuse .gitignore files directly, and I just did that for my dotfiles (  https://bitbucket.org/nicdumz/dotfiles/commits/b0387132e769a2ec31c9e65264d65e2e7212778a & https://bitbucket.org/nicdumz/dotfiles/commits/3503e1bab25bf4269d9cd38f3027c62ca15e164e )

I think just a little bit of documentation in that direction could help a lot.

Hope it's useful.
Cheers!