### PR TITLE
Add $GIBO_BOILERPLATES var for local repo location

### DIFF
--- a/gibo
+++ b/gibo
@@ -7,7 +7,7 @@
 # v1.0 1-May-2012 First public release
 
 remote_repo=https://github.com/github/gitignore.git
-local_repo=$HOME/.gitignore-boilerplates
+local_repo=${GIBO_BOILERPLATES:-"$HOME/.gitignore-boilerplates"}
 current_repo_rev=$(git -C $local_repo rev-parse HEAD)
 remote_web_root=https://raw.github.com/github/gitignore/$current_repo_rev
 

--- a/gibo-completion.bash
+++ b/gibo-completion.bash
@@ -25,7 +25,7 @@
 _gibo()
 {
     local cur opts
-    opts=$( find $HOME/.gitignore-boilerplates -name "*.gitignore" -exec basename \{\} .gitignore \; )
+    opts=$( find ${GIBO_BOILERPLATES:-"$HOME/.gitignore-boilerplates"} -name "*.gitignore" -exec basename \{\} .gitignore \; )
     cur="${COMP_WORDS[COMP_CWORD]}"
 
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )


### PR DESCRIPTION
Allow override location of `local_repo` by setting shell variable to allow
storing local repo somewhere like `$XDG_CACHE_HOME`