### PR TITLE
Improve zsh completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ following in your .bashrc:
 
 ### zsh instructions
 
-Copy `gibo-completion.zsh` somewhere (e.g. ~/.gibo-completion.zsh)
+Copy `gibo-completion.zsh` somewhere (e.g. ~/.zsh/_gibo)
 and put the following in your .zshrc:
 
-    source ~/.gibo-completion.zsh
+    fpath=(~/.zsh $fpath)
 
 Alternatively, you can use `gibo-completion.zsh` as an
 [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) plugin

--- a/gibo-completion.zsh
+++ b/gibo-completion.zsh
@@ -1,4 +1,4 @@
-#!/zsh
+#compdef gibo
 #
 # Zsh completion for gibo
 #
@@ -12,10 +12,10 @@
 #
 #     autoload -U compinit && compinit
 #
-# Then copy this file somewhere (e.g. ~/.gibo-completion.zsh) and put the
+# Then copy this file somewhere (e.g. ~/.zsh/_gibo) and put the
 # following in your .zshrc:
 #
-#     source ~/.gibo-completion.zsh
+#     fpath=(~/.zsh $fpath)
 #
 # CREDITS
 #
@@ -23,9 +23,16 @@
 
 _gibo()
 {
-    local_repo=${GIBO_BOILERPLATES:-"$HOME/.gitignore-boilerplates"}
+    local local_repo=${GIBO_BOILERPLATES:-"$HOME/.gitignore-boilerplates"}
+    local -a boilerplates
     if [ -e "$local_repo" ]; then
-        compadd -M 'm:{[:lower:]}={[:upper:]}' $( find "$local_repo" -name "*.gitignore" -exec basename \{\} .gitignore \; )
+        boilerplates=($local_repo/**/*.gitignore(:r:t))
     fi
+
+    _arguments \
+        {-l,--list}'[List available boilerplates]' \
+        {-u,--upgrade}'[Upgrade list of available boilerplates]' \
+        {-h,--help}'[Display this help text]' \
+        {-v,--version}'[Display current script version]' \
+        "*:boilerplate:($boilerplates)"
 }
-compdef _gibo gibo


### PR DESCRIPTION
This includes 3 improvements for zsh completion.

- Enable function autoloading.

	When `gibo-completions.zsh` is copied as `_gibo` into the directory contained in `$fpath`, running `source path/to/gibo-completion.zsh` becomes unnecessary.

- Improve performance of listing boilerplate files by replacing `find` command with globbing.

	`find` command with `-exec basename` argument  takes several hundreds of milliseconds but globbing doesn't take so much time.

	```
	$/usr/bin/time find ~/.gitignore-boilerplates -name "*.gitignore" -exec basename \{\} .gitignore \; > /dev/null
        0.47 real         0.15 user         0.20 sys
	
	$/usr/bin/time echo ~/.gitignore-boilerplates/**/*.gitignore(:r:t) > /dev/null
        0.00 real         0.00 user         0.00 sys
	```

- Complete options, too.

	```
	$ gibo -[press TAB]
	--help     -h  -- Display this help text
	--list     -l  -- List available boilerplates
	--upgrade  -u  -- Upgrade list of available boilerplates
	--version  -v  -- Display current script version
	```
