### PR TITLE
Add git version for C option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 For additional usage instructions, run `gibo` without arguments.
 
+## Requirement
+git: 1.8.5 or more
+
 ## Installation
 
 ### Installation on OS X using [Homebrew](http://mxcl.github.com/homebrew/)


### PR DESCRIPTION
# information
This warning happened in my environment.

![image](https://cloud.githubusercontent.com/assets/4950792/22143089/234b66a4-df3c-11e6-9232-d11e7d58cc78.png)

```
$ git --version
git version 1.8.3.1
```

# Cause
'-C' option will be available from 1.8.5.
Concerned commit:
https://github.com/git/git/commit/44e1e4d67d5148c245db362cc48c3cc6c2ec82ca

# Solution
I added recommended version to README

Please review! 🙇 
