### PR TITLE
Force --ff option

### DIFF
--- a/gibo
+++ b/gibo
@@ -76,7 +76,7 @@ upgrade() {
         clone
     else
         cd "$local_repo"
-        git pull origin master
+        git pull --ff origin master
     fi
 }
 

--- a/gibo.bat
+++ b/gibo.bat
@@ -171,7 +171,7 @@ goto :setup
     if not exist "%local_repo%\.git" call :clone && goto :eof
 
     pushd "%local_repo%"
-    git pull origin master
+    git pull --ff origin master
     popd
 
     goto :eof


### PR DESCRIPTION
If `.gitconfig` always enable `--no-ff` option, then `gibo --upgrade` creates  unnecessary merge commit.
I think `--ff` option is expected as `gibo --upgrade` behaviour in spite of `.gitconfig` any settings.