### PR TITLE
Make search case-insensitive

### DIFF
--- a/gibo
+++ b/gibo
@@ -83,17 +83,17 @@ upgrade() {
 dump() {
     init --silently
 
-    language_file="$local_repo/$1.gitignore"
-    global_file="$local_repo/Global/$1.gitignore"
+    language_file=$(find "$local_repo" -maxdepth 1 -iname "$1.gitignore" | head -n 1)
+    global_file=$(find "$local_repo/Global" -maxdepth 1 -iname "$1.gitignore" | head -n 1)
 
-    if [ -e "$language_file" ]; then
-        echo "### $remote_web_root/$1.gitignore"
+    if [ -n "$language_file" ]; then
+        echo "### $remote_web_root/$(basename $language_file)"
         echo
         cat "$language_file"
         echo
         echo
-    elif [ -e "$global_file" ]; then
-        echo "### $remote_web_root/Global/$1.gitignore"
+    elif [ -n "$global_file" ]; then
+        echo "### $remote_web_root/Global/$(basename $global_file)"
         echo
         cat "$global_file"
         echo


### PR DESCRIPTION
I found there are two problems about case-sensitivity of file system.

* On case-sensitive file system, it is sometimes inconvenient that gibo cannot find a .gitignore if the case does not match.
For example, `gibo macOS` is OK but `gibo MacOS` is not.
* On case-insensitive file system, both `gibo macOS` and `gibo MacOS` works, but the URL added to the first line is wrong if the case does not match.
If I execute `gibo MacOS` I get a URL https://raw.github.com/github/gitignore/982268df04842c9b34b7bdb0c4b0696b7db6e6fd/Global/MacOS.gitignore, it's 404.

This patch fixes both problems by doing case-insensitive search and using actual filenames to make URLs. 

Perhaps the Windows version should also be changed, but I don't know much about Windows, need help.