### PR TITLE
Add docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine
+
+# install requirements
+RUN apk --no-cache --update add \
+      ca-certificates  git openssh util-linux && \
+      rm -rf /var/lib/apt/lists/* && \
+      rm /var/cache/apk/*
+
+RUN git clone https://github.com/github/gitignore.git /root/.gitignore-boilerplates
+COPY gibo gibo
+
+ENTRYPOINT ["./gibo"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Right-click [this link](https://raw.githubusercontent.com/simonwhitaker/gibo/mas
 
 A good directory to put the file is `C:\Users\<Your User>\bin` and add that directory to your system's PATH environment variable. Where ever you put it, make sure the batch file is accessible via `where gibo`.
 
+### Installation on Docker
+
+```sh
+$ docker build . -t simonwhitaker/gibo
+```
+
+#### Running on Docker
+
+```sh
+$ docker run simonwhitaker/gibo --list
+```
+
 ## Tab completion in bash, zsh and fish
 
 bash, zsh and fish users can enjoy the deluxe gibo experience by enabling tab


### PR DESCRIPTION
Add Dockerfile to allow using `gibo` under any environment with only docker.

NOTE: If you enable `automated build` on DockerHub, it will be easier to install the docker image as follows.

```
$ docker pull simonwhitaker/gibo
```