### PR TITLE
ignore command substitution stderr

### DIFF
--- a/gibo
+++ b/gibo
@@ -5,7 +5,7 @@
 
 remote_repo=https://github.com/github/gitignore.git
 local_repo=${GIBO_BOILERPLATES:-"$HOME/.gitignore-boilerplates"}
-current_repo_rev=$(cd $local_repo; git rev-parse HEAD)
+current_repo_rev=$(cd $local_repo 2>/dev/null && git rev-parse HEAD)
 remote_web_root=https://raw.github.com/github/gitignore/$current_repo_rev
 
 version() {


### PR DESCRIPTION
thanks for the cool tool!  
I wanna hidden stderr output if `$local_repo` not exist, so I changed two points.
- ignore stderr in `cd $local_repo`
- use `&&` to ignore `git rev-parse HEAD` if `$local_repo` not exist