### PR TITLE
Remove broken she-bang line

### DIFF
--- a/shell-completions/gibo-completion.bash
+++ b/shell-completions/gibo-completion.bash
@@ -1,5 +1,3 @@
-#!bash
-#
 # Bash completion for gibo
 #
 # INSTALLATION


### PR DESCRIPTION
It's invalid as it doesn't start with '/', i.e. providing a path to the
bash binary nor is it using '/usr/bin/env bash'. Removing is best since
it's not needed for bash-completions.