### PR TITLE
Improve connectivity with UNIX-Pipeline

### DIFF
--- a/gibo
+++ b/gibo
@@ -53,20 +53,25 @@ init() {
 list() {
     init
 
-    echo "=== Languages ==="
-    echo
+    if [ -t 1 ]; then
+        shape='column'
+    else
+        shape='cat'
+    fi
+
+    [ -t 1 ] && printf "=== Languages ===\n\n"
+
     for path in $(ls "$local_repo"/*.gitignore | sort -f); do
         filename=$(basename $path)
         echo "${filename%.*}"
-    done | column
+    done | eval ${shape}
 
-    echo
-    echo "=== Global ==="
-    echo
+    [ -t 1 ] && printf "\n=== Global ===\n\n"
+
     for path in $(ls "$local_repo"/Global/*.gitignore | sort -f); do
         filename=$(basename $path)
         echo "${filename%.*}"
-    done | column
+    done | eval ${shape}
 }
 
 search() {


### PR DESCRIPTION
### Issue:
Currently, `gibo list` display results with pretty columns similar to `ls` command.
but this is not suitable for connecting UNIX Pipe.
```sh
$ gibo list | grep roid
Android                 Grails                  Qt
```
`ls` command changes behabior whether output is terminal or not.
```sh
$ /bin/ls
Dockerfile  gibo  gibo.bat  README.md  shell-completions  UNLICENSE

$ ls | cat
Dockerfile
gibo
gibo.bat
README.md
shell-completions
UNLICENSE
```
This behavior convinient to processing with pipeline.

### PR:
Output words by each line and suppress extra messages if output is not a terminal.
use like this:
```sh
# grep
$ gibo list | grep -i mac

# fuzzy search & dump directly
$ gibo list | fzf | xargs gibo dump
```