### PR TITLE
Improve a performance of gibo list

### DIFF
--- a/gibo
+++ b/gibo
@@ -60,10 +60,8 @@ list() {
         shape='cat'
     fi
 
-    for path in $(find "$local_repo" -name '*.gitignore' | sort -f); do
-        filename=$(basename $path)
-        echo "${filename%.*}"
-    done | eval ${shape}
+    find "$local_repo" -name '*.gitignore' | sort -f \
+      | sed -e 's@^.*/\([^/]*\)\.gitignore$@\1@' | eval ${shape}
 }
 
 root() {


### PR DESCRIPTION
This PR improves a performance of `gibo list` about x10 to x30.

Here is a summary of improvement (average for 10 times iterations).

| Environment         | Ubuntu 18.04.2 LTS | Mac OS X 10.14.4 | Git Bash on Windows Server 1803 |
|---------------------|--------------------|------------------|---------------------------------|
| before [in seconds] |              0.187 |            0.706 |                           5.306 |
| after  [in seconds] |              0.014 |            0.032 |                           0.175 |
| improvement rate    |                x14 |              x22 |                             x30 |

This is tested on [travis ci](https://travis-ci.org/kai2nenobu/gibo/builds/561306421) virtual machines. See [this google spreadsheet](https://docs.google.com/spreadsheets/d/1HGBjULa2qrcMRQTZUz3smebq4XA_X1QRhgg-lQW5xA0/edit?usp=sharing) for more details.
