### PR TITLE
chore: change github/gitignore branch from "master" to "main"

### DIFF
--- a/gibo
+++ b/gibo
@@ -80,7 +80,7 @@ update() {
         clone
     else
         cd "$local_repo" || exit
-        git pull --ff origin master
+        git pull --ff origin main
     fi
 }
 

--- a/gibo.bat
+++ b/gibo.bat
@@ -173,7 +173,7 @@ goto :setup
     if not defined __cloned (
         echo updating..
         pushd "%local_repo%"
-        git pull -q --ff origin master
+        git pull -q --ff origin main
         popd
     )
 


### PR DESCRIPTION
"github/gitignore" seems to have changed the branch name from `master` to `main`.

Because of this, `gibo update` is not working now.

**Ref**:

- <https://github.com/github/gitignore/commit/093b0fbce96a7d35e3967bae2add4480a64949fd>
