### PR TITLE
[codex] Sync Docker Go version with go.mod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Check Dockerfile Go version sync
+        run: ./tools/sync-go-version.sh --check
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -12,5 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check Dockerfile Go version sync
+        run: ./tools/sync-go-version.sh --check
+
       - name: Docker build
         run: docker build -t gibo:latest .

--- a/.runny.yaml
+++ b/.runny.yaml
@@ -18,7 +18,13 @@ commands:
     run: go test ./...
 
   update-deps:
-    run: go get -u . && go mod tidy
+    run: |
+      go get -u .
+      go mod tidy
+      ./tools/sync-go-version.sh
+
+  check-go-version-sync:
+    run: ./tools/sync-go-version.sh --check
 
   check-goreleaser:
     run: goreleaser check .goreleaser.yaml .goreleaser.windows.yaml

--- a/tools/sync-go-version.sh
+++ b/tools/sync-go-version.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+mode="${1:-sync}"
+
+go_version=$(awk '/^go / { print $2; exit }' go.mod)
+
+if [ -z "$go_version" ]; then
+  echo "Unable to determine Go version from go.mod" >&2
+  exit 1
+fi
+
+go_image_version=$(echo "$go_version" | awk -F. '{ print $1 "." $2 }')
+expected_image="golang:${go_image_version}-alpine"
+expected_from="FROM ${expected_image} AS build"
+current_from=$(awk '/^FROM golang:[^ ]+ AS build$/ { print; exit }' Dockerfile)
+
+if [ -z "$current_from" ]; then
+  echo "Unable to determine Go build image from Dockerfile" >&2
+  exit 1
+fi
+
+if [ "$mode" = "--check" ]; then
+  if [ "$current_from" != "$expected_from" ]; then
+    echo "Dockerfile Go image is out of sync with go.mod" >&2
+    echo "Expected: ${expected_from}" >&2
+    echo "Found:    ${current_from}" >&2
+    exit 1
+  fi
+
+  exit 0
+fi
+
+if [ "$mode" != "sync" ]; then
+  echo "Usage: $0 [sync|--check]" >&2
+  exit 1
+fi
+
+if [ "$current_from" = "$expected_from" ]; then
+  exit 0
+fi
+
+tmp_file=$(mktemp)
+
+awk -v expected_from="$expected_from" '
+  BEGIN { updated = 0 }
+  /^FROM golang:[^ ]+ AS build$/ && !updated {
+    print expected_from
+    updated = 1
+    next
+  }
+  { print }
+' Dockerfile > "$tmp_file"
+
+mv "$tmp_file" Dockerfile


### PR DESCRIPTION
This change fixes a dependency-update failure mode where `runny update-deps` can raise the Go version in `go.mod` but leave the Docker build pinned to an older `golang:<version>-alpine` image, causing `docker build` to fail before the binary is built. The root cause is that the supported Go version was effectively defined in two places, with `go.mod` moving automatically during dependency updates and `Dockerfile` remaining a separate manual edit.

The fix adds `tools/sync-go-version.sh` to derive the Docker builder image from the `go` directive in `go.mod`, wires that script into `runny update-deps`, and adds an explicit `--check` guard so both Docker CI and the release Docker workflow fail fast if the files drift out of sync. I validated the change by running `./tools/sync-go-version.sh --check`, simulating a mismatched Docker base image to confirm the guard fails with a targeted error, and running `docker build -t gibo:test .` successfully.
