### PR TITLE
[codex] Add prek sync-go-version hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: sync-go-version
+        name: Sync Go version
+        language: system
+        entry: tools/sync-go-version.sh
+        always_run: true
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,23 @@
 
 Just push a version tag (e.g. `v3.0.1`) to Github.
 
+## Pre-commit checks
+
+This repository uses `prek` for local pre-commit checks.
+
+Install and enable the hooks with:
+
+```sh
+brew install prek
+prek install
+```
+
+Run the configured checks manually with:
+
+```sh
+prek run --all-files
+```
+
 ## To release a new version manually
 
 1. Install [GoReleaser](https://goreleaser.com/):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,4 @@
-# To release a new version automatically
-
-Just push a version tag (e.g. `v3.0.1`) to Github.
+# Contributing
 
 ## Pre-commit checks
 
@@ -19,7 +17,13 @@ Run the configured checks manually with:
 prek run --all-files
 ```
 
-## To release a new version manually
+## Releases
+
+### To release a new version automatically
+
+Just push a version tag (e.g. `v3.0.1`) to Github.
+
+### To release a new version manually
 
 1. Install [GoReleaser](https://goreleaser.com/):
 


### PR DESCRIPTION
This change adds a `prek` pre-commit hook that runs `tools/sync-go-version.sh` before each commit so contributors catch mismatches between `go.mod` and the Docker build image locally instead of after pushing changes. Without this check, the repository can drift into a state where the declared Go version and the Dockerfile’s build image diverge, which makes local and CI builds less predictable. The root cause was that the sync script existed but was not wired into any default developer workflow, so it was easy to miss. The fix adds a local `prek` hook configuration and documents how to install hooks and run them manually in the contributor guide. Validation: `prek run --all-files`.
