### PR TITLE
fix: recover from invalid cache directory (#70)

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -40,12 +40,19 @@ func cloneRepo(repo string) error {
 func cloneIfNeeded() error {
 	fileInfo, err := os.Stat(RepoDir())
 	if os.IsNotExist(err) {
-		err = cloneRepo(RepoDir())
-		if err != nil {
+		return cloneRepo(RepoDir())
+	}
+	if err != nil {
+		return err
+	}
+	if !fileInfo.IsDir() {
+		return fmt.Errorf("%v exists but is not a directory", RepoDir())
+	}
+	if _, err := git.PlainOpen(RepoDir()); err != nil {
+		if err := os.RemoveAll(RepoDir()); err != nil {
 			return err
 		}
-	} else if !fileInfo.IsDir() {
-		return fmt.Errorf("%v exists but is not a directory", RepoDir())
+		return cloneRepo(RepoDir())
 	}
 	return nil
 }
@@ -134,7 +141,9 @@ func ListBoilerplatesNoError() []string {
 }
 
 func Update() (string, error) {
-	cloneIfNeeded()
+	if err := cloneIfNeeded(); err != nil {
+		return "", err
+	}
 	r, err := git.PlainOpen(RepoDir())
 	if err != nil {
 		return "", err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -49,6 +49,9 @@ func cloneIfNeeded() error {
 		return fmt.Errorf("%v exists but is not a directory", RepoDir())
 	}
 	if _, err := git.PlainOpen(RepoDir()); err != nil {
+		if err != git.ErrRepositoryNotExists {
+			return err
+		}
 		if err := os.RemoveAll(RepoDir()); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes #70. If a prior clone of the gitignore boilerplate repo was interrupted (e.g. network drop), the cache directory was left behind without a valid git repo inside, so subsequent `gibo` invocations failed with "repository does not exist" and had no way to recover short of manually deleting the cache.

`cloneIfNeeded` now verifies the cache dir is a valid git repo via `git.PlainOpen`, and re-clones if not. `Update` also now propagates the `cloneIfNeeded` error instead of discarding it.

## Test plan
- [x] `go test ./...`
- [x] Manually reproduced the bug by creating an empty stale cache dir, confirmed `gibo update` and `gibo dump Python` both now recover